### PR TITLE
Dokku/Heroku support files

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,1 @@
+https://github.com/heroku/heroku-buildpack-python.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+install:
+  - "pip install ."
+  - "pip install -r requirements.txt"

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: uwsgi uwsgi.ini

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,9 @@ dateutils
 flask
 Flask-RESTful
 xlrd
+twisted
+lxml
+w3lib
+cryptography
+uwsgi
+cssselect

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -1,0 +1,9 @@
+[uwsgi]
+http-socket = :$(PORT)
+master = true
+processes = 4
+die-on-term = true
+callable = app
+wsgi-file = app.py
+master = true
+chdir = app


### PR DESCRIPTION
These extra files allow easy deployment to Heroku and [Dokku](https://github.com/progrium/dokku) as @bennokr and I talked about yesterday.
Allows deployment using one command (!). Actually needs PR #26 for configuring elasticsearch backend using environment variables.

```Shell
$ git push dokku dokku:master
Counting objects: 4, done.
Delta compression using up to 12 threads.
Compressing objects: 100% (4/4), done.
Writing objects: 100% (4/4), 475 bytes | 0 bytes/s, done.
Total 4 (delta 2), reused 0 (delta 0)
-----> Cleaning up ...
-----> Building ooapi2 ...
-----> Fetching custom buildpack
-----> Multipack app detected
       =====> Downloading Buildpack: https://github.com/heroku/heroku-buildpack-python.git
       =====> Detected Framework: Python
-----> Noticed cffi. Bootstrapping libffi.
-----> Installing dependencies with pip
[...]
       using profile: buildconf/default.ini
       detected include path: ['/app/.heroku/python/include', '/usr/lib/gcc/x86_64-linux-gnu/4.8/include', '/usr/local/include', '/usr/lib/gcc/x86_64-linux-gnu/4.8/include-fixed', '/usr/include/x86_64-linux-gnu', '/usr/include']
[..]
       Successfully installed Flask-RESTful-0.3.1 Jinja2-2.7.3 Pygments-2.0.2 Sphinx-1.2.3 Werkzeug-0.9.6 aniso8601-0.92 argparse-1.3.0 cffi-0.8.6 colander-1.0b1 cryptography-0.7.2 cssselect-0.9.1 dateutils-0.6.6 docutils-0.12 flask-0.10.1 itsdangerous-0.24 lxml-3.4.1 markupsafe-0.23 pyOpenSSL-0.14 python-dateutil-2.4.0 pytz-2014.10 queuelib-1.2.2 rawes-0.5.5 requests-2.5.1 scrapy-0.24.4 six-1.9.0 sphinxcontrib-httpdomain-1.3.0 translationstring-1.3 twisted-14.0.2 uwsgi-2.0.9 w3lib-1.11.0 xlrd-0.9.3 zope.interface-4.1.2

       Using release configuration from last framework (Python).
-----> Discovering process types
       Procfile declares types -> web
-----> Releasing ooapi2 ...
-----> Deploying ooapi2 ...
-----> Running pre-flight checks
       check-deploy: /home/dokku/ooapi2/CHECKS not found. attempting to retrieve it from container ...
       CHECKS file not found in container. skipping checks.
-----> Running post-deploy
-----> Configuring ooapi2.dokku.dnet...
-----> Creating http nginx.conf
-----> Running nginx-pre-reload
       Reloading nginx
-----> Shutting down old container in 60 seconds
=====> Application deployed:
       http://ooapi2.dokku.dnet

To dokku@dokku.dnet:ooapi2
   a068857..0fc6657  dokku -> master
```

