### PR TITLE
add pyyaml to dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,10 @@ flask
 Flask-RESTful
 Flask-Cors==1.10.2
 xlrd
+twisted
+lxml
+w3lib
+cryptography
+uwsgi
+cssselect
+pyyaml


### PR DESCRIPTION
When I tried to run the API webapp on a clean machine, I was missing some python dependencies.

This change adds the python dependencies used by [dsbaars@dokku](https://github.com/dsbaars/openonderwijsdata-api/tree/dokku) branch as well as pyyaml (for the config).