### PR TITLE
explicitly add the python elasticsearch bindings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,10 @@ flask
 Flask-RESTful
 Flask-Cors==1.10.2
 xlrd
+twisted
+lxml
+w3lib
+cryptography
+uwsgi
+cssselect
+pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ cryptography
 uwsgi
 cssselect
 pyyaml
+elasticsearch==1.4.0


### PR DESCRIPTION
Hi,

On my working VM, the jobfeed import script needed the `elasticsearch` pip dependency.
Please add it to the requirements.txt

kind regards,
Ties
